### PR TITLE
Add missing parenthesis to taskforpid test

### DIFF
--- a/tests/taskforpid.c
+++ b/tests/taskforpid.c
@@ -10,7 +10,7 @@
 int main(void)
 {
     mach_port_t port;
-    if (task_for_pid(mach_task_self(), 0, &port)
+    if (task_for_pid(mach_task_self(), 0, &port))
     {
         printf("[ERRROR] Can't get task_for_pid() for kernel task!\n");
     }


### PR DESCRIPTION
Actually this test is broken (or has been patched in 10.9) since it will always print `[ERRROR] Can't get task_for_pid() for kernel task!`, no matter if you're using gdb or not (without onyx).

Also, the onyx option for `task_for_pid(0)` doesn't change anything.
